### PR TITLE
feat(dx): standardize local npm scripts for DX workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ yarn-error.log*
 
 # Dependency directories
 node_modules/
+package-lock.json
 
 # ApexPMD cache
 .pmdCache

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+.idea/
+IlluminatedCloud/
+.npm-cache/
+node_modules/
+.github/agents/
+AGENTS.md
+eslint.config.js
+jest.config.js

--- a/package.json
+++ b/package.json
@@ -4,14 +4,17 @@
   "version": "1.0.0",
   "description": "Salesforce App",
   "scripts": {
-    "lint": "eslint **/{aura,lwc}/**/*.js",
+    "lint": "eslint \"force-app/main/default/**/{aura,lwc}/**/*.js\" --no-error-on-unmatched-pattern",
+    "format": "npm run prettier",
     "test": "npm run test:unit",
     "test:unit": "sfdx-lwc-jest",
+    "test:unit:ci": "sfdx-lwc-jest -- --ci --passWithNoTests",
     "test:unit:watch": "sfdx-lwc-jest --watch",
     "test:unit:debug": "sfdx-lwc-jest --debug",
     "test:unit:coverage": "sfdx-lwc-jest --coverage",
     "prettier": "prettier --write \"**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}\"",
     "prettier:verify": "prettier --check \"**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}\"",
+    "validate": "npm run lint && npm run prettier:verify && npm run test:unit:ci",
     "prepare": "husky || true",
     "precommit": "lint-staged"
   },
@@ -38,7 +41,7 @@
       "eslint"
     ],
     "**/lwc/**": [
-        "sfdx-lwc-jest -- --bail --findRelatedTests --passWithNoTests"
+      "sfdx-lwc-jest -- --bail --findRelatedTests --passWithNoTests"
     ]
   }
 }


### PR DESCRIPTION
Refs #4

## Summary
- standardize local DX npm scripts in `package.json` for lint, format, validate, and CI-friendly unit test execution
- add `.prettierignore` entries for local/editor/generated files that should not be formatted
- add `package-lock.json` to `.gitignore` and intentionally keep it out of this PR
