### PR TITLE
ci: harden security gates and align runbook (issue #8)

### DIFF
--- a/.github/workflows/security-gates.yml
+++ b/.github/workflows/security-gates.yml
@@ -1,0 +1,128 @@
+name: Security Gates
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-gates-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  secret-scan:
+    name: Secret Scan (Fail on Findings)
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="8.28.0"
+          archive="gitleaks_${version}_linux_x64.tar.gz"
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${version}/${archive}"
+
+          curl -fsSL "$url" -o /tmp/$archive
+          tar -xzf /tmp/$archive -C /tmp gitleaks
+          install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Run Gitleaks
+        id: gitleaks
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          artifacts_dir=".artifacts/security"
+          report_path="$artifacts_dir/gitleaks.sarif"
+          mkdir -p "$artifacts_dir"
+
+          set +e
+          gitleaks git --redact --no-banner --report-format sarif --report-path "$report_path" .
+          gitleaks_exit=$?
+          set -e
+
+          # The enforcement step consumes this exact exit code.
+          echo "exit_code=$gitleaks_exit" >> "$GITHUB_OUTPUT"
+
+      - name: Enforce secret scan fail policy
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ steps.gitleaks.outputs.exit_code }}" != "0" ]; then
+            echo "::error title=Secret scan failed::Potential secret exposure detected. Per policy, secret-scan findings block merge until remediated or covered by an approved time-boxed exception (RUNBOOK.md Section 11)."
+            exit 1
+          fi
+
+      - name: Upload secret scan artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: secret-scan-${{ github.run_id }}
+          path: .artifacts/security/gitleaks.sarif
+          if-no-files-found: ignore
+
+  dependency-audit:
+    name: Dependency Audit (High/Critical Gate)
+    if: github.event_name == 'pull_request' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run npm audit with fail policy
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          artifacts_dir=".artifacts/security"
+          audit_file="$artifacts_dir/npm-audit.json"
+          mkdir -p "$artifacts_dir"
+
+          set +e
+          npm audit --audit-level=high --json > "$audit_file"
+          audit_exit=$?
+          set -e
+
+          node -e "const fs=require('fs');const p=process.argv[1];const data=JSON.parse(fs.readFileSync(p,'utf8'));const v=(data.metadata&&data.metadata.vulnerabilities)||{};console.log('npm audit summary => critical:',v.critical||0,'high:',v.high||0,'moderate:',v.moderate||0,'low:',v.low||0);" "$audit_file"
+
+          if [ "$audit_exit" -ne 0 ]; then
+            echo "::error title=Dependency audit failed::High/Critical vulnerabilities detected. See artifact npm-audit.json and follow RUNBOOK.md triage/exceptions process."
+            exit "$audit_exit"
+          fi
+
+      - name: Upload dependency audit artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dependency-audit-${{ github.run_id }}
+          path: .artifacts/security/npm-audit.json
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@
   npm run validate
   ```
 - PR CI also runs `.github/workflows/pr-check.yml`; when a PR changes files under `force-app/` (or `SFDX_METADATA_DIR`), it adds a Salesforce metadata validate-only gate.
+- Security CI runs `.github/workflows/security-gates.yml` with secret scanning on `pull_request` + `push: main` and dependency audit on `pull_request` + `schedule`.
 
 ## Project-Specific Conventions
 - Use **ESLint flat config** (`eslint.config.js`), not legacy `.eslintrc*`.
@@ -57,6 +58,7 @@
 - API version is pinned to `66.0` (`sfdx-project.json`); align new metadata with this target unless intentionally upgraded.
 - Ignore local IDE/state directories in automation (`.sf/`, `.sfdx/`, `.illuminatedCloud/`, `IlluminatedCloud/`).
 - CI metadata validation authenticates with `sf org login sfdx-url`; keep auth material in GitHub secrets only and do not assume local `.sf/` or `.sfdx/` state exists on runners.
+- Security incidents and temporary risk acceptances must follow `RUNBOOK.md` triage/exception process (owner + reason + expiration + rollback trigger).
 
 ## Agent Operating Guidance for This Repo
 - Before editing, inspect `force-app/main/default/` to detect which metadata types are present in the current branch.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ PR workflow `.github/workflows/pr-check.yml` always runs:
 - `npm run prettier:verify`
 - `npm run test:lwc:ci`
 
+Security workflow `.github/workflows/security-gates.yml` runs:
+
+- secret scanning on `pull_request` and `push` to `main`;
+- dependency audit on `pull_request` and weekly `schedule`;
+- fail policy: any secret-scan finding fails the job, and dependency findings with severity `high` or `critical` fail the job;
+- approved, time-boxed exceptions must follow `RUNBOOK.md` Section 11 with owner, reason, and expiration.
+
 If a PR changes files under `force-app/` (or under the directory defined by repository variable `SFDX_METADATA_DIR`), the workflow also runs a Salesforce metadata validate-only check.
 
 This check requires:
@@ -101,6 +108,7 @@ The runbook covers:
 - lint and LWC test behavior in an empty template;
 - reasons for graceful skip in `npm run test:apex`;
 - diagnostics for failure and skip scenarios of `Salesforce Metadata Validate` in PRs.
+- security triage and exception lifecycle for secret scan and dependency audit findings.
 
 ## Additional Test Modes
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -163,3 +163,74 @@ To speed up diagnostics, include:
 - exact command and full output;
 - Node/npm versions (`node -v`, `npm -v`);
 - for CI issues: a run link and log from artifact `salesforce-validate-<run_id>`.
+
+---
+
+## 9) Security gate fails on secret scanning
+
+### Symptom
+
+Job `Secret Scan (Fail on Findings)` fails in `.github/workflows/security-gates.yml`.
+
+### Actions
+
+1. Open artifact `secret-scan-<run_id>` and review `gitleaks.sarif`.
+2. Confirm whether the finding is a real secret (token, key, password, private key) or false positive.
+3. If real:
+   - immediately rotate/revoke the exposed credential;
+   - remove secret from repository history if required by policy;
+   - push a remediation commit and re-run checks.
+4. If false positive, follow Section 11 (time-boxed exception) and add an owner for cleanup.
+
+### SLA
+
+- `critical`: remediate or block merge within 4 hours.
+- `high`: remediate or block merge within 1 business day.
+
+### Fail policy
+
+- Any secret-scan finding in `.github/workflows/security-gates.yml` fails CI on `pull_request` and `push` to `main`.
+- Merge is blocked until remediation is merged or a documented, time-boxed exception is approved (Section 11).
+
+---
+
+## 10) Security gate fails on dependency audit
+
+### Symptom
+
+Job `Dependency Audit (High/Critical Gate)` fails due to `npm audit --audit-level=high`.
+
+### Actions
+
+1. Open artifact `dependency-audit-<run_id>` and inspect `npm-audit.json`.
+2. Identify direct vs transitive vulnerable packages.
+3. Apply the safest upgrade path (`npm update`, explicit version bump, or dependency replacement).
+4. Re-run CI and confirm no `high`/`critical` findings remain.
+5. If no safe fix exists yet, follow Section 11 and create a time-boxed exception.
+
+### Fail policy
+
+- Any `high` or `critical` dependency vulnerability fails CI.
+- `moderate`/`low` do not block merge by default, but should be triaged.
+
+---
+
+## 11) Exception lifecycle (time-boxed risk acceptance)
+
+Use exceptions only when an immediate safe remediation is not available.
+
+### Required fields
+
+- `owner`: accountable engineer.
+- `reason`: why the exception is required.
+- `scope`: affected workflow/finding/package/path.
+- `expiration_date`: hard deadline for removal.
+- `rollback_trigger`: condition that cancels the exception immediately (for example, fix released, active exploit, policy update).
+
+### Process
+
+1. Create an issue with all required fields and link CI run evidence.
+2. Obtain approval from the code owner/security reviewer.
+3. Apply the minimum temporary bypass needed.
+4. Track expiration and remove the bypass before `expiration_date`.
+5. Close the issue only after cleanup is merged and CI is green without the bypass.


### PR DESCRIPTION
## Что сделано
- исправлен secret-scan job в `.github/workflows/security-gates.yml`:
  - заменён неподдерживаемый `gitleaks/gitleaks-action` вызов с `with.args` на явный CLI запуск `gitleaks`
  - добавлен fail-enforcement шаг по exit code сканера
  - сохранена выгрузка SARIF артефакта
- закреплены `uses` в security workflow на commit SHA (`checkout`, `setup-node`, `upload-artifact`)
- синхронизирован `RUNBOOK.md` с актуальным именем job `Secret Scan (Fail on Findings)`
- добавлены/уточнены runbook разделы по triage и time-boxed exception lifecycle

## Проверка
- `npx prettier --check .github/workflows/security-gates.yml RUNBOOK.md`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/security-gates.yml"); puts "YAML OK"'`

## Связь
Closes #8